### PR TITLE
SSO\Client::getResponseUrl must be public

### DIFF
--- a/src/SSO/Client.php
+++ b/src/SSO/Client.php
@@ -72,7 +72,7 @@ class Client
     return hash_hmac('sha256', $this->getDecodedPayload(), $this->getSecret());
   }
 
-  protected function getResponseUrl(array $userParams)
+  public function getResponseUrl(array $userParams)
   {
     return $this->getCallbackUrl() . '?' . $this->getResponseQuery($userParams);
   }


### PR DESCRIPTION
If it's protected the suggested code won't work:

```php
FatalErrorException in SsoController.php line 69:
Call to protected method Vinkas\Discourse\PHP\SSO\Client::getResponseUrl() from context 'App\Http\Controllers\Auth\SsoController'
```

```php
$sso = $discourse->sso('SECRET');

if ($sso->isValid()) {
  $userParams = array(
      'external_id' => 'USER_ID',
      'email'     => 'EMAIL_ADDRESS',
      'username' => 'USERNAME',  // optional
      'name'     => 'FULL_NAME'  // optional
      // for more available fields https://meta.discourse.org/t/official-single-sign-on-for-discourse/13045
  );

  header('Location: ' . $sso->getResponseUrl($userParams));
}
```